### PR TITLE
Fix typo in tests

### DIFF
--- a/tests/testBDB.py
+++ b/tests/testBDB.py
@@ -28,7 +28,7 @@ class TestBDB(unittest.TestCase):
     # copy
     db.copy(DBNAME)
     # close
-    db.close
+    db.close()
     os.remove(DBNAME2)
 
     # open

--- a/tests/testHDB.py
+++ b/tests/testHDB.py
@@ -24,7 +24,7 @@ class TestHDB(unittest.TestCase):
     # copy
     db.copy(DBNAME)
     # close
-    db.close
+    db.close()
     os.remove(DBNAME2)
 
     # open


### PR DESCRIPTION
The tests are sample code, so calling close properly is a good idea even if it's not tested.
