### PR TITLE
Fix `SystemError` when looking up empty string key

### DIFF
--- a/pytc.c
+++ b/pytc.c
@@ -449,11 +449,12 @@ typedef struct {
   func(type *self, PyObject *_key) { \
     PyObject *ret; \
     char *key = PyString_AsString(_key), *value; \
-    int key_len = PyString_GET_SIZE(_key), value_len; \
+    int key_len, value_len; \
   \
-    if (!key || !key_len) { \
+    if (!key) { \
       return NULL; \
     } \
+    key_len = PyString_GET_SIZE(_key); \
     Py_BEGIN_ALLOW_THREADS \
     value = call(self->member, key, key_len, &value_len); \
     Py_END_ALLOW_THREADS \


### PR DESCRIPTION
When looking up the empty string as a key, this test will incorrectly return `NULL`, without setting an exception, which then makes Python raise a `SystemError` instead.
The fix is to remove the test for `key_len` being zero, because the `PyString_GET_SIZE()` macro cannot actually fail and does not have an error return value.